### PR TITLE
depends: Make default `host` and `build` comparable

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -52,7 +52,6 @@ C_STANDARD ?= c11
 CXX_STANDARD ?= c++20
 
 BUILD = $(shell ./config.guess)
-HOST ?= $(BUILD)
 PATCHES_PATH = $(BASEDIR)/patches
 BASEDIR = $(CURDIR)
 HASH_LENGTH:=11
@@ -60,11 +59,6 @@ DOWNLOAD_CONNECT_TIMEOUT:=30
 DOWNLOAD_RETRIES:=3
 HOST_ID_SALT ?= salt
 BUILD_ID_SALT ?= salt
-
-host:=$(BUILD)
-ifneq ($(HOST),)
-host:=$(HOST)
-endif
 
 ifneq ($(DEBUG),)
 release_type=debug
@@ -75,8 +69,14 @@ endif
 base_build_dir=$(WORK_PATH)/build
 base_staging_dir=$(WORK_PATH)/staging
 base_download_dir=$(WORK_PATH)/download
-canonical_host:=$(shell ./config.sub $(HOST))
 build:=$(shell ./config.sub $(BUILD))
+
+host:=$(build)
+ifneq ($(HOST),)
+host:=$(HOST)
+endif
+HOST ?= $(BUILD)
+canonical_host:=$(shell ./config.sub $(HOST))
 
 build_arch =$(firstword $(subst -, ,$(build)))
 build_vendor=$(word 2,$(subst -, ,$(build)))


### PR DESCRIPTION
To detect cross-compiling, the host and build platforms are compared. The `build` variable is always an output of `config.sub`, but the `host` is not. This can lead to false results. For example, on OpenBSD:
 - host=amd64-unknown-openbsd7.5
 - build=x86_64-unknown-openbsd7.5

This change sets the default value of the `host` variable to the value of `build`, ensuring cross-compiling won't be triggered when the `HOST` variable is not set.