### PR TITLE
gui: Fix proxy details display in Options Dialog

### DIFF
--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -320,10 +320,15 @@ static ProxySetting ParseProxyString(const QString& proxy)
     if (proxy.isEmpty()) {
         return default_val;
     }
-    // contains IP at index 0 and port at index 1
-    QStringList ip_port = GUIUtil::SplitSkipEmptyParts(proxy, ":");
-    if (ip_port.size() == 2) {
-        return {true, ip_port.at(0), ip_port.at(1)};
+    uint16_t port{0};
+    std::string hostname;
+    if (SplitHostPort(proxy.toStdString(), port, hostname) && port != 0) {
+        // Valid and port within the valid range
+        // Check if the hostname contains a colon, indicating an IPv6 address
+        if (hostname.find(':') != std::string::npos) {
+            hostname = "[" + hostname + "]"; // Wrap IPv6 address in brackets
+        }
+        return {true, QString::fromStdString(hostname), QString::number(port)};
     } else { // Invalid: return default
         return default_val;
     }


### PR DESCRIPTION
- Ensured that the proxy IP is displayed correctly in the UI when using an IPv6 address.

No functionality impact; changes only affect UI display.