### PR TITLE
depends: For mingw cross compile use -gcc-posix to prevent library conflict

### DIFF
--- a/depends/hosts/mingw32.mk
+++ b/depends/hosts/mingw32.mk
@@ -1,3 +1,6 @@
+ifneq ($(shell $(SHELL) $(.SHELLFLAGS) "command -v $(host)-gcc-posix"),)
+mingw32_CC := $(host)-gcc-posix
+endif
 ifneq ($(shell $(SHELL) $(.SHELLFLAGS) "command -v $(host)-g++-posix"),)
 mingw32_CXX := $(host)-g++-posix
 endif


### PR DESCRIPTION
CMake parses some paths from the spec of the C compiler, assuming it will be the linker, resulting in the link to end up with `-L/usr/lib/gcc/x86_64-w64-mingw32/12-win32` on debian bookworm if both -win32 and -posix variants are installed, and -win32 is the default alternative.

This results in the wrong C++ library being linked, missing std::threads::hardware_concurrency and other threading functions.

To fix this, use the -posix variant of gcc as well when available. This fixes a regression compared to autotools, where this scenario worked.