### PR TITLE
init: fix fatal error on '-wallet' negated option value

### DIFF
--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -77,6 +77,11 @@ bool VerifyWallets(WalletContext& context)
     std::set<fs::path> wallet_paths;
 
     for (const auto& wallet : chain.getSettingsList("wallet")) {
+        if (!wallet.isStr()) {
+            chain.initError(_("Invalid value detected for '-wallet' or '-nowallet'. "
+                              "'-wallet' requires a string value, while '-nowallet' accepts only '1' to disable all wallets"));
+            return false;
+        }
         const auto& wallet_file = wallet.get_str();
         const fs::path path = fsbridge::AbsPathJoin(GetWalletDir(), fs::PathFromString(wallet_file));
 
@@ -110,6 +115,11 @@ bool LoadWallets(WalletContext& context)
     try {
         std::set<fs::path> wallet_paths;
         for (const auto& wallet : chain.getSettingsList("wallet")) {
+            if (!wallet.isStr()) {
+                chain.initError(_("Invalid value detected for '-wallet' or '-nowallet'. "
+                                  "'-wallet' requires a string value, while '-nowallet' accepts only '1' to disable all wallets"));
+                return false;
+            }
             const auto& name = wallet.get_str();
             if (!wallet_paths.insert(fs::PathFromString(name)).second) {
                 continue;

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -153,6 +153,13 @@ class ConfArgsTest(BitcoinTestFramework):
             expected_msg='Error: Error parsing command line arguments: Can not set -proxy with no value. Please specify value with -proxy=value.',
             extra_args=['-proxy'],
         )
+        # Provide a value different from 1 to the -wallet negated option
+        if self.is_wallet_compiled():
+            for value in [0, 'not_a_boolean']:
+                self.nodes[0].assert_start_raises_init_error(
+                    expected_msg="Error: Invalid value detected for '-wallet' or '-nowallet'. '-wallet' requires a string value, while '-nowallet' accepts only '1' to disable all wallets",
+                    extra_args=[f'-nowallet={value}'],
+                )
 
     def test_log_buffer(self):
         self.stop_node(0)


### PR DESCRIPTION
Because we don't have type checking for command-line/settings/config args, strings are interpreted as 'false' for non-boolean args. By convention, this "forces" us to interpret negated strings as 'true', which conflicts with the negated option definition in all the settings classes (they expect negated options to always be false and ignore any other value preceding them). Consequently, when retrieving all "wallet" values from the command-line/settings/config, we also fetch the negated string boolean value, which is not of the expected 'string' type.

This mismatch leads to an internal fatal error, resulting in an unclean shutdown during initialization. Furthermore, this error displays a poorly descriptive error message:
"JSON value of type bool is not of expected type string"

This commit fixes the fatal error by ensuring that only string values are returned in the "wallet" settings list, failing otherwise. It also improves the clarity of the returned error message.